### PR TITLE
Precedence to integer order over lexicographical.

### DIFF
--- a/marmo-ui.user.js
+++ b/marmo-ui.user.js
@@ -272,7 +272,16 @@ function runMarmoUI()
 					{
 						if($.text([a]) == $.text([b]))
 							return 0;
-						return ($.text([a]) > $.text([b])) ? (inverse ? -1 : 1) : (inverse ? 1 : -1);
+
+						a = $.text([a]);
+						b = $.text([b]);
+						
+						if(parseInt(a) && parseInt(b)) {
+							a = parseInt(a);
+							b = parseInt(b);
+						} 
+
+						return a > b ? (inverse ? -1 : 1) : (inverse ? 1 : -1);
 					}, function()
 					{
 						return this.parentNode; //The tr is what we want to move


### PR DESCRIPTION
- MarmoUI was ordering the test number lexigraphically, which made the results weird past `#9`.
- Integer order is preferred over lexicographical order.
