### PR TITLE
Add support for other marmoset urls

### DIFF
--- a/MarmoUI-Chrome/manifest.json
+++ b/MarmoUI-Chrome/manifest.json
@@ -7,12 +7,13 @@
   "icons": {
     "16": "image/icon16.png",
     "48": "image/icon48.png",
-    "128": "image/icon128.png" 
+    "128": "image/icon128.png"
   },
-  
+
   "content_scripts": [
     {
-      "matches": ["https://marmoset.student.cs.uwaterloo.ca/*"],
+      "matches": ["https://*.uwaterloo.ca/*"],
+      "include_globs": ["https://marmoset*"],
       "js": ["scripts/script.js"]
     }
   ],


### PR DESCRIPTION
This PR adds support for alternative Marmoset deployments. 

ECE, for example, uses the following URLS:
```
https://marmoset01.shoshin.uwaterloo.ca
https://marmoset03.shoshin.uwaterloo.ca
```

I tried to make this as general as possible - any Marmoset deployment on `*.uwaterloo.ca` is now supported.
