### PR TITLE
Fixed parsing token form dates

### DIFF
--- a/MarmoUI-Chrome/scripts/script.js
+++ b/MarmoUI-Chrome/scripts/script.js
@@ -328,7 +328,11 @@ function runMarmoUI()
             return Date.parse((new Date()).getFullYear() + " " + date.split(",")[1].match(/[a-zA-Z0-9 \:]+/)[0].trim().replace(" at ", " "));
         }
         try {
-            return shortForm() || longForm() || tokenForm();
+			if(date.match(/(19|20)\d{2}/))
+				return longForm();
+			if(date.match(/([mM]on|[tT]ues|[wW]ed(nes)?|[tT]hur(s)?|[fF]ri|[sS]at(ur)?|[sS]un)(day)?/))
+				return tokenForm();
+			return shortForm();
         }
         catch (err){
             return false;

--- a/MarmoUI-Chrome/scripts/script.js
+++ b/MarmoUI-Chrome/scripts/script.js
@@ -328,11 +328,8 @@ function runMarmoUI()
             return Date.parse((new Date()).getFullYear() + " " + date.split(",")[1].match(/[a-zA-Z0-9 \:]+/)[0].trim().replace(" at ", " "));
         }
         try {
-			if(date.match(/(19|20)\d{2}/))
-				return longForm();
-			if(date.match(/([mM]on|[tT]ues|[wW]ed(nes)?|[tT]hur(s)?|[fF]ri|[sS]at(ur)?|[sS]un)(day)?/))
-				return tokenForm();
-			return shortForm();
+						if (date.match(/(19|20)\d{2}/)) return longForm();
+						return shortForm() || tokenForm();
         }
         catch (err){
             return false;

--- a/marmo-ui.user.js
+++ b/marmo-ui.user.js
@@ -327,11 +327,8 @@ function runMarmoUI()
             return Date.parse((new Date()).getFullYear() + " " + date.split(",")[1].match(/[a-zA-Z0-9 \:]+/)[0].trim().replace(" at ", " "));
         }
         try {
-			if(date.match(/(19|20)\d{2}/))
-				return longForm();
-			if(date.match(/([mM]on|[tT]ues|[wW]ed(nes)?|[tT]hur(s)?|[fF]ri|[sS]at(ur)?|[sS]un)(day)?/))
-				return tokenForm();
-			return shortForm();
+						if (date.match(/(19|20)\d{2}/)) return longForm();
+						return shortForm() || tokenForm();
         }
         catch (err){
             return false;

--- a/marmo-ui.user.js
+++ b/marmo-ui.user.js
@@ -327,7 +327,11 @@ function runMarmoUI()
             return Date.parse((new Date()).getFullYear() + " " + date.split(",")[1].match(/[a-zA-Z0-9 \:]+/)[0].trim().replace(" at ", " "));
         }
         try {
-            return shortForm() || longForm() || tokenForm();
+			if(date.match(/(19|20)\d{2}/))
+				return longForm();
+			if(date.match(/([mM]on|[tT]ues|[wW]ed(nes)?|[tT]hur(s)?|[fF]ri|[sS]at(ur)?|[sS]un)(day)?/))
+				return tokenForm();
+			return shortForm();
         }
         catch (err){
             return false;


### PR DESCRIPTION
fixed a bug where "token form" dates were parsed using the "long form" method, producing the correct date but in the year 2001.

Example:
Wed, 15 Sep at 12:48 PM -> 15 Sep 12:48 PM 
Date.parse("15 Sep 12:48 PM") -> 1000572480000