### PR TITLE
Improve token display on course pages

### DIFF
--- a/MarmoUI-Chrome/scripts/script.js
+++ b/MarmoUI-Chrome/scripts/script.js
@@ -664,8 +664,8 @@ function runMarmoUI()
 			}
 			catch(error)
 			{
-				//Set to 3 tokens if we can't find the token string
-				tableCell.html("3");
+				//Set to N/A if we can't find the token string
+				tableCell.html("N/A");
 			}
 		}
 

--- a/MarmoUI-Chrome/scripts/script.js
+++ b/MarmoUI-Chrome/scripts/script.js
@@ -645,14 +645,15 @@ function runMarmoUI()
 			try
 			{
 				//Grab the token from the page
-				var tokens = requestResult.match(/You currently have \d+ release/)[0].match(/\d+/)[0];
+				var tokens = requestResult.match(/You currently have (\d+) release/)[1];
 				var tokenText = tokens;
+				//Get list of pending tokens
+				var pendingTokens = requestResult.match(/\<li\>[a-zA-Z0-9 ,\:]+\<br\>/g);
 				//Find the next release token availability
-				if(tokens < 3)
+				if(pendingTokens)
 				{
 					//First release token
-					var tokens = requestResult.match(/\<li\>[a-zA-Z0-9 ,\:]+\<br\>/g);
-					var tmp = tokens[tokens.length - 1];
+					var tmp = pendingTokens[tokens.length - 1];
 					//Calculate time difference
 					var nextToken = parseMarmosetDate(tmp) - Date.now();
 					//Add in the text for the next token time

--- a/MarmoUI-Chrome/scripts/script.js
+++ b/MarmoUI-Chrome/scripts/script.js
@@ -652,10 +652,8 @@ function runMarmoUI()
 				//Find the next release token availability
 				if(pendingTokens)
 				{
-					//First release token
-					var tmp = pendingTokens[tokens.length - 1];
 					//Calculate time difference
-					var nextToken = parseMarmosetDate(tmp) - Date.now();
+					var nextToken = parseMarmosetDate(pendingTokens[0]) - Date.now();
 					//Add in the text for the next token time
 					tokenText += " (renew in " + Math.floor(nextToken / 3600000) + "h " + Math.floor((nextToken % 3600000) / 60000) + "m)";
 				}

--- a/marmo-ui.user.js
+++ b/marmo-ui.user.js
@@ -644,8 +644,8 @@ function runMarmoUI()
 			}
 			catch(error)
 			{
-				//Set to 3 tokens if we can't find the token string
-				tableCell.html("3");
+				//Set to N/A if we can't find the token string
+				tableCell.html("N/A");
 			}
 		}
 

--- a/marmo-ui.user.js
+++ b/marmo-ui.user.js
@@ -625,14 +625,15 @@ function runMarmoUI()
 			try
 			{
 				//Grab the token from the page
-				var tokens = requestResult.match(/You currently have \d+ release/)[0].match(/\d+/)[0];
+				var tokens = requestResult.match(/You currently have (\d+) release/)[1];
 				var tokenText = tokens;
+				//Get list of pending tokens
+				var pendingTokens = requestResult.match(/\<li\>[a-zA-Z0-9 ,\:]+\<br\>/g);
 				//Find the next release token availability
-				if(tokens < 3)
+				if(pendingTokens)
 				{
 					//First release token
-					var tokens = requestResult.match(/\<li\>[a-zA-Z0-9 ,\:]+\<br\>/g);
-					var tmp = tokens[tokens.length - 1];
+					var tmp = pendingTokens[tokens.length - 1];
 					//Calculate time difference
 					var nextToken = parseMarmosetDate(tmp) - Date.now();
 					//Add in the text for the next token time

--- a/marmo-ui.user.js
+++ b/marmo-ui.user.js
@@ -632,10 +632,8 @@ function runMarmoUI()
 				//Find the next release token availability
 				if(pendingTokens)
 				{
-					//First release token
-					var tmp = pendingTokens[tokens.length - 1];
 					//Calculate time difference
-					var nextToken = parseMarmosetDate(tmp) - Date.now();
+					var nextToken = parseMarmosetDate(pendingTokens[0]) - Date.now();
 					//Add in the text for the next token time
 					tokenText += " (renew in " + Math.floor(nextToken / 3600000) + "h " + Math.floor((nextToken % 3600000) / 60000) + "m)";
 				}


### PR DESCRIPTION
This pull request addresses a few issues with the token column shown on course pages:

* Only try to generate a renewal message when a pending token is found. This fixes #6.
* Default N/A instead of 3 if no token message is found. This is needed since there are courses like CS136L that don't use release tokens.
* Show the renewal message for the token that is renewing the soonest.